### PR TITLE
Added build-git-with-azure-dev-ops-links.md

### DIFF
--- a/SampleTemplates/GenerateReleaseNotes (Original Powershell based)/build-git-with-azure-dev-ops-links.md
+++ b/SampleTemplates/GenerateReleaseNotes (Original Powershell based)/build-git-with-azure-dev-ops-links.md
@@ -1,0 +1,15 @@
+[[_TOC_]]
+# Release notes for build $defname
+**Build Number**  : $($build.buildnumber)
+**Build started** : $("{0:dd/MM/yy HH:mm:ss}" -f [datetime]$build.startTime)
+**Source Branch** $($build.sourceBranch)
+
+## Associated work items
+@@WILOOP@@
+#$($widetail.id) [Assigned by: $($widetail.fields.'System.AssignedTo'.displayName)] $($widetail.fields.'System.Title')
+@@WILOOP@@
+
+## Associated change sets/commits
+@@CSLOOP@@
+[$($csdetail.commitid.substring(0,7))](https://dev.azure.com/{org}/{project}/_git/{repo}/commit/$($csdetail.commitid)) $($csdetail.comment)
+@@CSLOOP@@


### PR DESCRIPTION
A build template that contains links for Azure DevOps commits and work items. Works great with the Wiki Updater extension.

### What problem does this PR address?
Provides examples for how to create links to Azure DevOps.
  
### Is there a related Issue?
No
  
